### PR TITLE
Address MongoError: ns not found

### DIFF
--- a/artifacts/db-reset.js
+++ b/artifacts/db-reset.js
@@ -61,11 +61,11 @@ MongoClient.connect(db, (err, db) =>  {
     console.log("Connected to the database: " + db);
 
     // remove existing data (if any), we don't want to look for errors here
-    db.dropCollection("users");
-    db.dropCollection("allocations");
-    db.dropCollection("contributions");
-    db.dropCollection("memos");
-    db.dropCollection("counters");
+    // db.dropCollection("users");
+    // db.dropCollection("allocations");
+    // db.dropCollection("contributions");
+    // db.dropCollection("memos");
+    // db.dropCollection("counters");
 
     const usersCol = db.collection("users");
     const allocationsCol = db.collection("allocations");


### PR DESCRIPTION
Address `MongoError: ns not found` error (seems related to non-existent collections):

> `MongoError: ns not found` occurs when performing actions on collections that don't exist.

Reference: https://stackoverflow.com/questions/37136204/mongoerror-ns-not-found-when-try-to-drop-collection